### PR TITLE
basic pagination added to  sales table

### DIFF
--- a/src/components/SaleComponent/SalesTable.js
+++ b/src/components/SaleComponent/SalesTable.js
@@ -1,10 +1,14 @@
-import React from "react";
+import React, { useState } from "react";
 import "../../styles/Table.css";
 import { Link } from "react-router-dom";
 import { FaEdit } from 'react-icons/fa';
+import { FaArrowAltCircleLeft, FaArrowAltCircleRight } from 'react-icons/fa';
 
-const SalesTable = ({ sales }) => {
-    const tableItems = sales.map(item => {
+const SalesTable = ({ data }) => {
+    const [currentPage, setCurrentPage] = useState(0);
+    const [perPage, setPerPage] = useState(5);
+
+    const tableItems = data.map(item => {
         return (
             <tr key={item._id}>
                 <td>{item.category}</td>
@@ -16,6 +20,23 @@ const SalesTable = ({ sales }) => {
             </tr>
         )
     });
+
+    // slice the data to show only current page data
+    const currentData = tableItems.slice(currentPage * perPage, (currentPage + 1) * perPage);
+
+    // handle pagination
+    const prevPage = () => {
+        if (currentPage > 0) {
+            setCurrentPage(currentPage - 1)
+        }
+    }
+
+    const nextPage = () => {
+        const totalPages = Math.ceil(tableItems.length / perPage);
+        if (currentPage < (totalPages - 1)) {
+            setCurrentPage(currentPage + 1)
+        }
+    }
 
     return (
         <div className="child-container">
@@ -30,9 +51,12 @@ const SalesTable = ({ sales }) => {
                     </tr>
                 </thead>
                 <tbody>
-                    {tableItems}
+                    {currentData}
                 </tbody>
             </table>
+            <button onClick={prevPage}><FaArrowAltCircleLeft className="icon"/></button>
+            <span>{currentPage + 1}</span>
+            <button onClick={nextPage}><FaArrowAltCircleRight className="icon"/></button>
         </div>
     )
 }

--- a/src/containers/Sales.js
+++ b/src/containers/Sales.js
@@ -67,7 +67,7 @@ const Sales = () => {
                 handleProductChange={handleProductChange}
                 handleStaffMemberChange={handleStaffMemberChange}
                 handleDateChange={handleDateChange} />
-            <SalesTable sales={sales}/>
+            <SalesTable data={sales}/>
         </div>
     )
 }


### PR DESCRIPTION
I've added basic pagination under sales table. I didn't install any npm package, just handled things with states. For now it's only moving one page at a time and displays 5 rows per page. It's structured for a small set of data just for project showcase event. Later I'll work on a full pagination feature to handle bigger datasets.